### PR TITLE
Add docker-compose config

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ served through Docker. The game runs in a browser using a canvas element.
 
 ## Running with Docker
 
-Build the Docker image and run it:
+Build the Docker image and run it manually:
 
 ```bash
 docker build -t dart-breakout ./breakout
@@ -13,3 +13,15 @@ docker run -p 8080:80 dart-breakout
 ```
 
 Then open `http://localhost:8080` in your browser to play the game.
+
+## Running with Docker Compose
+
+Alternatively, you can use Docker Compose. This will build the image
+and start the container with a single command:
+
+```bash
+docker compose up --build
+```
+
+After it starts, open `http://localhost:8080` in your browser to play
+the game.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  breakout:
+    build: ./breakout
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Summary
- add a docker-compose.yml to build and run the Dart Breakout game
- document Docker Compose usage in README

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848031a79088333aa168a78926b5301