### PR TITLE
Add overlay z-index for proper screen transitions

### DIFF
--- a/breakout/web/index.html
+++ b/breakout/web/index.html
@@ -16,6 +16,7 @@
       justify-content: center;
       align-items: center;
       background: rgba(0, 0, 0, 0.5);
+      z-index: 1;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- ensure the start screen overlay is layered above the canvas

## Testing
- `dart format --set-exit-if-changed breakout/web/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea13a2a08333add16869889ba475